### PR TITLE
💄 Move gitmoji underline to the background

### DIFF
--- a/src/components/Gitmoji.svelte
+++ b/src/components/Gitmoji.svelte
@@ -81,6 +81,7 @@
     border-radius: 4px;
     background-color: var(--color);
     animation: 0.15s slideRight;
+    z-index: -1;
   }
 
   @keyframes slideRight {


### PR DESCRIPTION
Problem: The underline of the gitmoji shortcode that appear when you `hover` it cover the letters like `g-p-q-...`. I propose to move it in the back to be covered by the letters.

What do you think of this new UI @Lyokolux?