### PR TITLE
🐛 fix github pr merge ui integration

### DIFF
--- a/src/injectMergeGitmoji.js
+++ b/src/injectMergeGitmoji.js
@@ -26,7 +26,13 @@ export const getPlatform = () => {
 }
 
 const getCommitTitleInput = (platform) => {
-  if (platform === 'github') return document.querySelector('input[name="commit_title"]')
+  if (platform === 'github') {
+    const newUIInput = document.querySelector('input[data-component="input"]')
+    if (newUIInput) return newUIInput
+
+    return document.querySelector('input[name="commit_title"]')
+  }
+
   if (platform === 'gitlab') return document.getElementById('merge-message-edit')
 
   return null
@@ -63,6 +69,10 @@ chrome.storage.local.get([INJECT_GITMOJI_SETTINGS_KEY], (result) => {
 
   if (inject) {
     const observer = new MutationObserver(() => { injectMergeGitmoji(type) })
-    observer.observe(document.body, { attributes: true, childList: true })
+    observer.observe(document.body, {
+      attributes: true,
+      childList: true,
+      subtree: true
+    })
   }
 })


### PR DESCRIPTION
Hey @johannchopin,

This PR fixes the issue with GitHub's new PR merge interface where the extension fails to inject gitmojis into the commit message field. The selector logic has been updated to support both the old and new GitHub UIs.

**Changes**
- Updated `getCommitTitleInput` function to first look for the new selector (`input[data-component="input"]`) and then fall back to the old one
- Added `subtree: true` to the MutationObserver options to improve detection of UI changes

Close: #203